### PR TITLE
Build binaries for arm64

### DIFF
--- a/setuptools/_distutils/msvc9compiler.py
+++ b/setuptools/_distutils/msvc9compiler.py
@@ -381,8 +381,8 @@ class MSVCCompiler(CCompiler) :
             self.cc = self.find_exe("cl.exe").replace('HostX64', 'Hostx86')
             self.linker = self.find_exe("link.exe").replace('HostX64', 'Hostx86')
             self.lib = self.find_exe("lib.exe").replace('HostX64', 'Hostx86')
-            self.rc = self.find_exe("rc.exe").replace('x64', 'x86')   # resource compiler
-            self.mc = self.find_exe("mc.exe").replace('x64', 'x86')   # message compiler
+            self.rc = self.find_exe("rc.exe").replace('x64', 'arm64')   # resource compiler
+            self.mc = self.find_exe("mc.exe").replace('x64', 'arm64')   # message compiler
             #self.set_path_env_var('lib')
             #self.set_path_env_var('include')
 

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -27,6 +27,7 @@ import zipimport
 import shutil
 import tempfile
 import zipfile
+import platform
 import re
 import stat
 import random
@@ -2236,7 +2237,9 @@ def get_win_launcher(type):
     Returns the executable as a byte string.
     """
     launcher_fn = '%s.exe' % type
-    if is_64bit():
+    if platform.machine().lower() == 'arm64':
+        launcher_fn = launcher_fn.replace(".", "-arm64.")
+    elif is_64bit():
         launcher_fn = launcher_fn.replace(".", "-64.")
     else:
         launcher_fn = launcher_fn.replace(".", "-32.")


### PR DESCRIPTION
Before running setup.py install, you need to run the following:

```cmd

set CL_PATH"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\bin\HostX86\ARM64\cl.exe"

%CL_PATH% /D "GUI=0" /D "WIN32_LEAN_AND_MEAN" /D _ARM64_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE launcher.c /O2 /link /MACHINE:ARM64 /SUBSYSTEM:CONSOLE /out:setuptools/cli-arm64.exe
    
```

See https://github.com/pypa/setuptools/commit/16361e51b834153f2e0e96897ebf33163c18016b